### PR TITLE
Use 24-hour time format in screenshot and screen recording filenames

### DIFF
--- a/archcraft-scripts/files/bin/screenrecorder
+++ b/archcraft-scripts/files/bin/screenrecorder
@@ -5,7 +5,7 @@
 
 ## Record Screen with slop and ffmpeg
 
-time=`date +%Y-%m-%d-%I-%M`
+time=`date +%Y-%m-%d-%H-%M-%S`
 screen=`xrandr | head -n1 | cut -d',' -f2 | tr -d '[:blank:],current'`
 dir="`xdg-user-dir VIDEOS`/Screenrecorder"
 file="Capture_${time}.mp4"

--- a/archcraft-scripts/files/bin/takeshot
+++ b/archcraft-scripts/files/bin/takeshot
@@ -5,7 +5,7 @@
 
 ## Script to take screenshots with maim
 
-time=`date +%Y-%m-%d-%I-%M-%S`
+time=`date +%Y-%m-%d-%H-%M-%S`
 geometry=`xrandr | head -n1 | cut -d',' -f2 | tr -d '[:blank:],current'`
 dir="`xdg-user-dir PICTURES`/Screenshots"
 file="Screenshot_${time}_${geometry}.png"


### PR DESCRIPTION
In scripts `takeshot` and `screenrecorder`, they use 12-hour date format. The problem is that file sorting becomes a mess. For example, there are two screenshots, one is taken at 5:10 am, and the other is at 5:05 pm. For the user, this confuses them because they cannot tell which shot is taken at which time. It also breaks actual time order for both screenshots.

Also in `screenrecorder`, the timestamp generated is only up to minutes. This may override existing recordings that is made within that same minute.

This PR changes both scripts so that they use 24-hour date format and maintain chronological order. Also, `screenrecorder` now includes seconds in its timestamp.