### PR TITLE
Fix archcraft-randr --off 'position'

### DIFF
--- a/archcraft-randr/archcraft-randr
+++ b/archcraft-randr/archcraft-randr
@@ -45,6 +45,8 @@ function main() {
       position='--primary'
     fi
     xrandr_cmd+=" --output ${output} ${position} ${mode}"
+    position=''
+    mode=''
   done
 
   ${=xrandr_cmd}


### PR DESCRIPTION
While looping all outputs, if an output is marked to be positioned as `--off`, then no mode option should be appended (xrandr will then not treat the `--off` switch). The current solution on line `40` worked only if the previous mode was set to auto and not an actual resolution (xrandr works with both `--auto` and `--off` but not with `--mode`). The if guard on line 40 was supposed to prevent it, but the mode variable wasn't cleared each iteration so the if guard didn't really help. The proposed solution is to clear the mode and position variables each iteration.